### PR TITLE
this fixes another issue

### DIFF
--- a/src/ffmpeg/AVFormat/v55/avformat.jl
+++ b/src/ffmpeg/AVFormat/v55/avformat.jl
@@ -282,8 +282,8 @@ function av_probe_input_buffer(pb,fmt,filename,logctx,offset::Integer,max_probe_
 end
 
 function avformat_open_input(ps,filename,fmt,options)
-    #ccall((:avformat_open_input,libavformat),Cint,(Ptr{Ptr{AVFormatContext}},Ptr{Uint8},Ptr{AVInputFormat},Ptr{Ptr{AVDictionary}}),ps,filename,fmt,options)
-    ccall((:avformat_open_input,libavformat),Cint,(Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void}),ps,filename,fmt,options)
+    ccall((:avformat_open_input,libavformat),Cint,(Ptr{Ptr{AVFormatContext}},Ptr{Uint8},Ptr{AVInputFormat},Ptr{Ptr{AVDictionary}}),ps,filename,fmt,options)
+    #ccall((:avformat_open_input,libavformat),Cint,(Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void}),ps,filename,fmt,options)
 end
 
 function av_demuxer_open(ic)


### PR DESCRIPTION
The error was:
```Julia
julia> f = VideoIO.openvideo("C:\\Users\\Sim\\Desktop\\aLP7m7v_460sv.mp4")
ERROR: MethodError: `convert` has no method matching convert(::Type{Ptr{Void}}, ::ASCIIString)
This may have arisen from a call to the constructor Ptr{Void}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert{T}(::Type{Ptr{T}}, ::UInt64)
  convert{T}(::Type{Ptr{T}}, ::Int64)
  ...
 in unsafe_convert at no file:382
 in open_avinput at C:\Users\Sim\.julia\v0.4\VideoIO\src\avio.jl:212
 in AVInput at C:\Users\Sim\.julia\v0.4\VideoIO\src\avio.jl:240
 in AVInput at C:\Users\Sim\.julia\v0.4\VideoIO\src\avio.jl:225
 in VideoReader at C:\Users\Sim\.julia\v0.4\VideoIO\src\avio.jl:368
 in openvideo at C:\Users\Sim\.julia\v0.4\VideoIO\src\avio.jl:486
```