### PR TITLE
Added seekstart (fixes #58)

### DIFF
--- a/test/avio.jl
+++ b/test/avio.jl
@@ -41,6 +41,19 @@ for name in VideoIO.TestVideos.names()
     while !eof(v)
         read!(v, img)
     end
+
+    # read first frames again, and compare
+    seekstart(v)
+
+    read!(v, img)
+
+    while notblank(img)
+        read!(v, img)
+    end
+
+    @test img == first_frame
+
+    close(v)
 end
 
 println(STDERR, "Testing IO reading...")


### PR DESCRIPTION
* Works, but if we try to seek to the start in the middle of the file
  there are a few frames remaining in the buffer, so it doesn't appear
  to seek right away