### PR TITLE
Update to travis container infrastructure (take 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+sudo: false
 addons:
   apt:
     packages:
     - imagemagick
+    - tcl8.5
+    - tk8.5
+    - libcairo2
+    - libavcodec-extra-53
+    - libavdevice53
+    - libavfilter2
+    - libavformat53
+    - libavutil-extra-51
+    - libswscale2
 os:
   - linux
 #  - osx


### PR DESCRIPTION
Note that this uses older library versions, because the newer versions still need to be wrapped