### PR TITLE
Adding seeking in video

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -510,7 +510,7 @@ have_frame(avin::AVInput) = any(Bool[have_frame(avin.stream_contexts[i+1]) for i
 reset_frame_flag!(r) = (r.aFrameFinished[1] = 0)
 
 function seconds_to_timestamp(s::Float64, time_base::AVRational)
-    return convert(Int64, s * time_base.den / time_base.num)
+    return convert(Int64, round(s *  convert(Float64, time_base.den) / convert(Float64, time_base.num)))
 end
 
 function seek(s::VideoReader, seconds::Float64,

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -1,6 +1,6 @@
 # AVIO
 
-import Base: read, read!, show, close, eof, isopen, seek, seekstart
+import Base: read, read!, show, close, eof, isopen, seekstart
 
 export read, read!, pump, openvideo, opencamera, playvideo, viewcam, play
 
@@ -509,33 +509,18 @@ have_frame(avin::AVInput) = any(Bool[have_frame(avin.stream_contexts[i+1]) for i
 
 reset_frame_flag!(r) = (r.aFrameFinished[1] = 0)
 
-function seconds_to_timestamp(s::Float64, time_base::AVRational)
-    return Int64(s * Float64(time_base.den) / Float64(time_base.num))
-end
-
-function seek(s::VideoReader, seconds::Float64;
-              seconds_min::Float64 = -1.0,  seconds_max::Float64 = -1.0,
-              video_stream::Int64=1, forward::Bool=false)
+function seekstart(s::VideoReader, video_stream=1)
     !isopen(s) && throw(ErrorException("Video input stream is not open!"))
-    fc = s.avin.apFormatContext[1]
 
     pCodecContext = s.pVideoCodecContext # AVCodecContext
 
-    seek(s.avin, seconds, seconds_min=seconds_min, seconds_max=seconds_max,
-         video_stream=video_stream, forward=forward)
-
+    seekstart(s.avin, video_stream)
     avcodec_flush_buffers(pCodecContext)
+
+    return s
 end
 
-function seek{T<:AbstractString}(avin::AVInput{T}, seconds::Float64 ;
-                                 seconds_min::Float64 = -1.0,  seconds_max::Float64 = -1.0,
-                                 video_stream::Int64 = 1, forward::Bool=true)
-
-    #Using 10 seconds before and after the desired timestamp, since the seek function
-    #seek to the nearest keyframe, and 10 seconds is the longest GOP length seen in
-    #practical usage.
-    const max_interval = Float64(10.0)
-
+function seekstart{T<:AbstractString}(avin::AVInput{T}, video_stream = 1)
     # AVFormatContext
     fc = avin.apFormatContext[1]
 
@@ -544,40 +529,13 @@ function seek{T<:AbstractString}(avin::AVInput{T}, seconds::Float64 ;
     seek_stream_index = stream_info.stream_index0
     stream = stream_info.stream
     first_dts = stream.first_dts
-    time_base = stream.time_base
-
-    #Timestamp calculations
-    if seconds_min < 0
-        seconds_min = max(seconds - max_interval, 0.0)
-    end
-
-    if seconds_max < 0
-        seconds_max = seconds + max_interval
-    end
-
-    dts = first_dts + seconds_to_timestamp(seconds, time_base)
-    min_dts = first_dts + seconds_to_timestamp(seconds_min, time_base)
-    max_dts = first_dts + seconds_to_timestamp(seconds_max, time_base)
-
-    flags = 0
-    if !forward
-        flags = AVSEEK_FLAG_BACKWARD
-    end
 
     # Seek
-    ret = avformat_seek_file(fc, seek_stream_index, min_dts, dts, max_dts, flags)
-    ret < 0 && throw(ErrorException("Could not seek in stream"))
+    ret = avformat_seek_file(fc, seek_stream_index, first_dts, first_dts, first_dts, AVSEEK_FLAG_BACKWARD)
+
+    ret < 0 && throw(ErrorException("Could not seek to start of stream"))
+
     return avin
-end
-
-function seekstart(s::VideoReader, video_stream=1)
-    return seek(s, 0.0, seconds_min=0.0, seconds_max=0.0,
-                video_stream=video_stream, forward=false)
-end
-
-function seekstart{T<:AbstractString}(avin::AVInput{T}, video_stream = 1)
-    return seek(avin, 0.0, seconds_min=0.0, seconds_max=0.0,
-                video_stream=video_stream, forward=false)
 end
 
 ## This doesn't work...

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -513,7 +513,7 @@ function seconds_to_timestamp(s::Float64, time_base::AVRational)
     return convert(Int64, s * time_base.den / time_base.num)
 end
 
-function seek(s::VideoReader, seconds::Float64, 
+function seek(s::VideoReader, seconds::Float64,
               seconds_min::Float64 = -1.0,  seconds_max::Float64 = -1.0,
               video_stream::Int64=1, forward::Bool=false)
     !isopen(s) && throw(ErrorException("Video input stream is not open!"))
@@ -521,12 +521,10 @@ function seek(s::VideoReader, seconds::Float64,
 
     pCodecContext = s.pVideoCodecContext # AVCodecContext
 
-
     seek(s.avin, seconds, seconds_min, seconds_max, video_stream, forward)
 
     avcodec_flush_buffers(pCodecContext)
 end
-
 
 function seek{T<:AbstractString}(avin::AVInput{T}, seconds::Float64,
                                  seconds_min::Float64 = -1.0,  seconds_max::Float64 = -1.0,

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -97,6 +97,42 @@ for name in VideoIO.TestVideos.names()
     end
 end
 
+println(STDERR, "Testing seeking...")
+
+#First keyframe on or after 1s
+kfnext = Dict([
+      ("annie_oakley.ogg", 65),
+      ("black_hole.webm", 25),
+      ("crescent-moon.ogv", 65),
+      ("ladybird.mp4", 31)
+      ])
+
+for name in VideoIO.TestVideos.names()
+    !haskey(kfnext, name) && continue
+    println(STDERR, "   Testing $name for seeking")
+    filename = joinpath(videodir, name)
+    v = VideoIO.openvideo(filename)
+
+    first_frame = read(v, Image)
+    seek(v, 1.0)
+    seek_frame = read(v, Image)
+
+    seekstart(v)
+    first_frame2 = read(v, Image)
+
+    kfnum = kfnext[name]
+    iter_frame = read(v, Image)
+    seek(v, 0.0)
+    for i in 1:kfnum
+        iter_frame = read(v, Image)
+    end
+
+    @test first_frame == first_frame2
+    @test seek_frame == iter_frame
+    close(v)
+    
+end
+
 VideoIO.testvideo("ladybird") # coverage testing
 @test_throws ErrorException VideoIO.testvideo("rickroll")
 @test_throws ErrorException VideoIO.testvideo("")


### PR DESCRIPTION
A new attempt to video seeking. This time tested on Julia 0.3, 0,4 and latest, and added tests. The tests did not run on Ubuntu 16.04 before I added my code, with the same problem as apparently was on OSX too, since the same video was conditionally excluded on OSX.  I have not fixed that, but can send a patch in a different pull request if required. The reason seems to be that 1080 is not divisible by 16, the macroblock size. 
