### PR TITLE
Update to the new Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 deps/*
 !deps/build.jl
 .DS_Store
+videos/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ julia:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("VideoIO2"); Pkg.test("VideoIO2"; coverage=true)'
+script:
+  - julia -e 'Pkg.clone(pwd())'
+  - julia -e 'Pkg.build("VideoIO")'
+  - if [ -f test/runtests.jl ]; then julia -e 'Pkg.test("VideoIO", coverage=true)'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ notifications:
 script:
   - julia -e 'Pkg.clone(pwd())'
   - julia -e 'Pkg.build("VideoIO")'
-  - if [ -f test/runtests.jl ]; then julia -e 'Pkg.test("VideoIO", coverage=true)'; fi
+  # coverage=true causes tests to hang, see pull request #92
+  - if [ -f test/runtests.jl ]; then julia -e 'Pkg.test("VideoIO", coverage=false)'; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,9 @@
-julia 0.4
-Compat 0.8.7
+julia 0.5
 BinDeps 0.3.4
-Images 0.4.4
-ImageView 0.1.4
+FixedPointNumbers 0.3.0
+ColorTypes
+FileIO
+ImageCore
+ImageView 0.3.0
 @osx Homebrew
 @linux Glob

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -1,3 +1,5 @@
+__precompile__(false)
+
 module VideoIO
 
 using Compat

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -2,7 +2,7 @@ __precompile__(false)
 
 module VideoIO
 
-using Compat
+using FixedPointNumbers, ColorTypes, ImageCore
 
 include("init.jl")
 

--- a/src/testvideos.jl
+++ b/src/testvideos.jl
@@ -46,7 +46,7 @@ const videofiles = Dict(
                                                     "pubic_domain (US)",
                                                     "",
                                                     "http://commons.wikimedia.org/wiki/File:Annie_Oakley_shooting_glass_balls,_1894.ogg",
-                                                    "http://upload.wikimedia.org/wikipedia/commons/d/dd/Annie_Oakley_shooting_glass_balls%2C_1894.ogg"),
+                                                    "https://upload.wikimedia.org/wikipedia/commons/8/87/Annie_Oakley_shooting_glass_balls%2C_1894.ogv"),
 
                     "crescent-moon.ogv" => VideoFile("crescent-moon.ogv",
                                                      "Moonset (time-lapse).",

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -13,7 +13,7 @@ swapext(f, new_ext) = "$(splitext(f)[1])$new_ext"
 
 println(STDERR, "Testing file reading...")
 
-function notblank(img)
+@noinline function notblank(img)
     all(c->green(c) == 0, img) || all(c->blue(c) == 0, img) || all(c->red(c) == 0, img) || maximum(rawview(channelview(img))) < 0xcf
 end
 

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -1,8 +1,6 @@
 using Base.Test
-using Compat
-using FixedPointNumbers
+using ColorTypes, FileIO, ImageCore
 
-import Images: Image
 import VideoIO
 
 testdir = dirname(@__FILE__)
@@ -15,18 +13,8 @@ swapext(f, new_ext) = "$(splitext(f)[1])$new_ext"
 
 println(STDERR, "Testing file reading...")
 
-if !isdefined(Main, :UFixed8)
-    UFixed8 = Ufixed8
-end
-
 function notblank(img)
-    all(Images.green(img) .== 0x00uf8) || all(Images.blue(img) .== 0x00uf8) || all(Images.red(img) .== 0x00uf8) || maximum(reinterpret(UFixed8, img)) < 0xcfuf8
-end
-
-if isdefined(Images, :load)
-    imload = Images.load
-else
-    imload = Images.imread
+    all(c->green(c) == 0, img) || all(c->blue(c) == 0, img) || all(c->red(c) == 0, img) || maximum(rawview(channelview(img))) < 0xcf
 end
 
 for name in VideoIO.TestVideos.names()
@@ -34,12 +22,16 @@ for name in VideoIO.TestVideos.names()
     println(STDERR, "   Testing $name...")
 
     first_frame_file = joinpath(testdir, swapext(name, ".png"))
-    first_frame = imload(first_frame_file) # comment line when creating png files
+    first_frame = load(first_frame_file) # comment line when creating png files
 
     f = VideoIO.testvideo(name)
     v = VideoIO.openvideo(f)
 
-    img = read(v, Image)
+    if size(first_frame, 1) > v.height
+        first_frame = first_frame[1+size(first_frame,1)-v.height:end,:]
+    end
+
+    img = read(v)
 
     # Find the first non-trivial image
     while notblank(img)
@@ -76,12 +68,16 @@ for name in VideoIO.TestVideos.names()
 
     println(STDERR, "   Testing $name...")
     first_frame_file = joinpath(testdir, swapext(name, ".png"))
-    first_frame = imload(first_frame_file) # comment line when creating png files
+    first_frame = load(first_frame_file) # comment line when creating png files
 
     filename = joinpath(videodir, name)
     v = VideoIO.openvideo(open(filename))
 
-    img = read(v, Image)
+    if size(first_frame, 1) > v.height
+        first_frame = first_frame[1+size(first_frame,1)-v.height:end,:]
+    end
+
+    img = read(v)
 
     # Find the first non-trivial image
     while notblank(img)


### PR DESCRIPTION
This performs a couple of cleanup operations, and then updates for recent changes in the FixedPointNumbers/Images landscape. Most significantly, it decouples Video from Images itself. In this version I have it relying on ImageCore (a much smaller package), but even that isn't really necessary: I think the only function I use from there is `permuteddimsview`, and that's basically a wrapper around `Base.PermutedDimsArrays.PermutedDimsArray`. (I use a little bit more functionality for the tests.) If you'd prefer to decouple entirely, that would be fine.

It does change the output type returned by `read`: rather than an `Image` that wraps an `Array{UInt8}`, it returns a (lazy-transposed, i.e., permuted) `Array{RGB{N0f8}}`. As a consequence, this is a breaking change.

This bumps the minimum julia version requirement, so if you like it this will need a minor-version bump when tagged.
