### PR TITLE
Fix v0.6 deprecations and drop v0.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ addons:
     - libcairo2
     - libavcodec-extra-54
     - libavdevice53
-    - libavfilter2
-    - libavformat53
-    - libavutil-extra-51
+    - libavfilter3
+    - libavformat54
+    - libavutil-extra-52
     - libswscale2
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:	
@@ -30,5 +29,4 @@ notifications:
 script:
   - julia -e 'Pkg.clone(pwd())'
   - julia -e 'Pkg.build("VideoIO")'
-  # coverage=true causes tests to hang, see pull request #92
-  - if [ -f test/runtests.jl ]; then julia -e 'Pkg.test("VideoIO", coverage=false)'; fi
+  - if [ -f test/runtests.jl ]; then julia -e 'Pkg.test("VideoIO", coverage=true)'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - tcl8.5
     - tk8.5
     - libcairo2
-    - libavcodec-extra-53
+    - libavcodec-extra-54
     - libavdevice53
     - libavfilter2
     - libavformat53

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ video frames from a supported video file, or from a camera device:
 
     # One can seek to an arbitrary position in the video
     seek(f,2.5)  ## The second parameter is the time in seconds and must be Float64
-    img = read(f, Image)
+    img = read(f)
     canvas, _ = ImageView.view(img)
     
     while !eof(f)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
-julia 0.5
-Compat v0.18.0
+julia 0.6
 BinDeps 0.3.4
 FixedPointNumbers 0.3.0
 ColorTypes

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -487,7 +487,7 @@ function seek(s::VideoReader, seconds::Float64,
     
     actualTimestamp = s.aVideoFrame[video_stream].pkt_dts   #av_frame_get_best_effort_timestamp(s.aVideoFrame)
     dts = first_dts + seconds_to_timestamp(seconds, stream.time_base)
-    frameskip = convert(Int64,(stream.time_base.den/stream.time_base.num)/(stream.r_frame_rate.num/stream.r_frame_rate.den))
+    frameskip = round(Int64,(stream.time_base.den/stream.time_base.num)/(stream.r_frame_rate.num/stream.r_frame_rate.den))
 
     while actualTimestamp < (dts - frameskip)
         while !have_frame(s)

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -487,6 +487,7 @@ function seek(s::VideoReader, seconds::Float64,
     
     actualTimestamp = s.aVideoFrame[video_stream].pkt_dts   #av_frame_get_best_effort_timestamp(s.aVideoFrame)
     dts = first_dts + seconds_to_timestamp(seconds, stream.time_base)
+    @show (stream.time_base.den/stream.time_base.num)/(stream.r_frame_rate.num/stream.r_frame_rate.den)
     frameskip = round(Int64,(stream.time_base.den/stream.time_base.num)/(stream.r_frame_rate.num/stream.r_frame_rate.den))
 
     while actualTimestamp < (dts - frameskip)

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -487,7 +487,6 @@ function seek(s::VideoReader, seconds::Float64,
     
     actualTimestamp = s.aVideoFrame[video_stream].pkt_dts   #av_frame_get_best_effort_timestamp(s.aVideoFrame)
     dts = first_dts + seconds_to_timestamp(seconds, stream.time_base)
-    @show (stream.time_base.den/stream.time_base.num)/(stream.r_frame_rate.num/stream.r_frame_rate.den)
     frameskip = round(Int64,(stream.time_base.den/stream.time_base.num)/(stream.r_frame_rate.num/stream.r_frame_rate.den))
 
     while actualTimestamp < (dts - frameskip)

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -4,19 +4,17 @@ import Base: read, read!, show, close, eof, isopen, seek, seekstart
 
 export read, read!, pump, openvideo, opencamera, playvideo, viewcam, play
 
-using Compat
-
 type StreamInfo
     stream_index0::Int             # zero-based
     stream::AVStream
     codec_ctx::AVCodecContext
 end
 
-abstract StreamContext
+abstract type StreamContext end
 
 const EightBitTypes = Union{UInt8, N0f8, Main.ColorTypes.RGB{N0f8}}
-@compat const PermutedArray{T,N,perm,iperm,AA<:Array} = Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm,iperm,AA}
-@compat const VidArray{T,N} = Union{Array{T,N},PermutedArray{T,N}}
+const PermutedArray{T,N,perm,iperm,AA<:Array} = Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm,iperm,AA}
+const VidArray{T,N} = Union{Array{T,N},PermutedArray{T,N}}
 
 # TODO: move this to Base
 Base.unsafe_convert{T}(::Type{Ptr{T}}, A::PermutedArray{T}) = Base.unsafe_convert(Ptr{T}, parent(A))
@@ -284,7 +282,7 @@ function VideoReader(avin::AVInput, video_stream=1;
     end
 
     N = Int64(bits_per_pixel >> 3)
-    target_buf = Array(UInt8, bits_per_pixel>>3, width, height)
+    target_buf = Array{UInt8}(bits_per_pixel>>3, width, height)
 
     sws_context = sws_getContext(width, height, pix_fmt,
                                  width, height, target_format,

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -28,6 +28,12 @@ for name in VideoIO.TestVideos.names()
     f = VideoIO.testvideo(name)
     v = VideoIO.openvideo(f)
 
+    # Verify that time base and framerate are finite and nonzero
+    @test v.stream_info.stream.time_base.num != 0
+    @test v.stream_info.stream.time_base.den != 0
+    @test v.stream_info.stream.r_frame_rate.num != 0
+    @test v.stream_info.stream.r_frame_rate.den != 0
+
     if size(first_frame, 1) > v.height
         first_frame = first_frame[1+size(first_frame,1)-v.height:end,:]
     end

--- a/util/wrap_libav_split.jl
+++ b/util/wrap_libav_split.jl
@@ -2,7 +2,6 @@
 import Clang.wrap_c
 import DataStructures: DefaultDict
 import Base.Meta.isexpr
-import Compat: String
 using Match
 
 include("../src/init.jl")


### PR DESCRIPTION
Thanks for making this project! I just noticed that it has a few deprecation warnings in v0.6, so I fixed the warnings. I also dropped v0.5 support, since it's almost time for v0.7/1.0, and dropping 0.5 will let FemtoCleaner magically help with some of the syntax changes. 