### PR TITLE
don't modify LOAD_PATH, and fix some deprecations on 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 VideoIO.jl
 ==========
 
-Julia bindings for libav/ffmpeg.  
+Julia bindings for libav/ffmpeg.
 
-Currently, only video reading is supported, for the following 
+Currently, only video reading is supported, for the following
 library versions:
 
 * libav 0.8, 9, 10
@@ -14,9 +14,9 @@ library versions:
 Video images may be read as raw arrays, or optionally, `Image`
 objects (if `Images.jl` is installed and loaded first).
 
-Feel free to request support for additional libav/ffmpeg 
+Feel free to request support for additional libav/ffmpeg
 versions, although earlier versions may be too challenging to
-support. 
+support.
 
 If you encounter any problems, please add the output
 of `VideoIO.versioninfo()` to your report.
@@ -41,13 +41,10 @@ A trivial video player interface exists (no audio):
     # Aternatively, you can just open the camera
     #VideoIO.viewcam()
 
-Note that `ImageView` must be imported before `VideoIO` for the `playvideo`
-function to be available.
-
 High Level Interface
 --------------------
 
-VideoIO contains a simple high-level interface which allows reading of 
+VideoIO contains a simple high-level interface which allows reading of
 video frames from a supported video file, or from a camera device:
 
     using Images
@@ -71,19 +68,18 @@ video frames from a supported video file, or from a camera device:
     seek(f,2.5)  ## The second parameter is the time in seconds and must be Float64
     img = read(f)
     canvas, _ = ImageView.view(img)
-    
+
     while !eof(f)
         read!(f, img)
         ImageView.imshow(canvas, img)
         #sleep(1/30)
     end
 
-This code is essentially the code in `playvideo`, and will read and 
+This code is essentially the code in `playvideo`, and will read and
 (without the `sleep`) play a movie file as fast as possible.
 
 As with the `playvideo` function, the `Images` and `ImageView` packages
-must be loaded before `VideoIO` for the appropriate functions to be
-available.
+must be loaded for the appropriate functions to be available.
 
 
 Low Level Interface
@@ -112,17 +108,17 @@ After importing VideoIO, you can import and use any of the subpackages directly
 Note that much of the functionality of these subpackages is not enabled
 by default, to avoid long compilation times as they load.  To control
 what is loaded, each library version has a file which imports that's
-modules files.  For example, ffmpeg's libswscale-v2 files are loaded by 
+modules files.  For example, ffmpeg's libswscale-v2 files are loaded by
 $(VideoIO_PKG_DIR)/src/ffmpeg/SWScale/v2/LIBSWSCALE.jl.
 
 Check these files to enable any needed functionality that isn't already
-enabled.  Note that you'll probably need to do this for each version 
+enabled.  Note that you'll probably need to do this for each version
 of the package for both ffmpeg and libav, and that the interfaces do
 change some from version to version.
 
 Note that, in general, the low-level functions are not very fun to use,
-so it is good to focus initially on enabling a nice, higher-level 
-function for these interfaces. 
+so it is good to focus initially on enabling a nice, higher-level
+function for these interfaces.
 
 Test Videos
 -----------
@@ -132,7 +128,7 @@ These are short videos in a variety of formats with non-restrictive
 (public domain or Creative Commons) licenses.
 
 * `VideoIO.TestVideos.available()` prints a list of all available test videos.
-* `VideoIO.testvideo("annie_oakley")` returns an AVInput object for the 
+* `VideoIO.testvideo("annie_oakley")` returns an AVInput object for the
   `"annie_oakley"` video.  The video will be downloaded if it isn't available.
 * `VideoIO.TestVideos.download_all()` downloads all test videos
 * `VideoIO.TestVideos.remove_all()` removes all test videos
@@ -144,5 +140,5 @@ At this point, a simple video interface is available, for multiple
 versions of libav and ffmpeg.  See TODO.md for some possible directions
 forward.
 
-Issues, requests, and/or pull requests for problems or additional 
+Issues, requests, and/or pull requests for problems or additional
 functionality are very welcome.

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ ImageCore
 ImageView 0.3.0
 @osx Homebrew
 @linux Glob
+Requires

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -2,7 +2,7 @@ __precompile__(false)
 
 module VideoIO
 
-using FixedPointNumbers, ColorTypes, ImageCore
+using FixedPointNumbers, ColorTypes, ImageCore, Requires
 
 include("init.jl")
 include(joinpath(av_load_path, "AVUtil", "src", "AVUtil.jl"))
@@ -20,5 +20,38 @@ include("util.jl")
 include("avio.jl")
 include("testvideos.jl")
 using .TestVideos
+
+function __init__()
+    @require ImageView="86fae568-95e7-573e-a6b2-d8a6b900c9ef" begin
+        # Define read and retrieve for Images
+        function play(f, flip=false)
+            buf = read(f)
+            canvas, _ = ImageView.imshow(buf, flipx=flip, interactive=false)
+
+            while !eof(f)
+                read!(f, buf)
+                ImageView.imshow(canvas, buf, flipx=flip, interactive=false)
+                sleep(1/f.framerate)
+            end
+        end
+
+        function playvideo(video)
+            f = VideoIO.openvideo(video)
+            play(f)
+        end
+
+        if have_avdevice()
+            function viewcam(device=DEFAULT_CAMERA_DEVICE, format=DEFAULT_CAMERA_FORMAT)
+                camera = opencamera(device, format)
+                play(camera, true)
+            end
+        else
+            function viewcam()
+                error("libavdevice not present")
+            end
+        end
+    end
+end
+
 
 end # VideoIO

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -5,11 +5,16 @@ module VideoIO
 using FixedPointNumbers, ColorTypes, ImageCore
 
 include("init.jl")
+include(joinpath(av_load_path, "AVUtil", "src", "AVUtil.jl"))
+include(joinpath(av_load_path, "AVCodecs", "src", "AVCodecs.jl"))
+include(joinpath(av_load_path, "AVFormat", "src", "AVFormat.jl"))
+include(joinpath(av_load_path, "AVDevice", "src", "AVDevice.jl"))
+include(joinpath(av_load_path, "SWScale", "src", "SWScale.jl"))
 
-using AVUtil
-using AVCodecs
-using AVFormat
-using SWScale
+using .AVUtil
+using .AVCodecs
+using .AVFormat
+using .SWScale
 
 include("util.jl")
 include("avio.jl")

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -13,7 +13,7 @@ end
 
 abstract type StreamContext end
 
-const EightBitTypes = Union{UInt8, N0f8, Main.ColorTypes.RGB{N0f8}}
+const EightBitTypes = Union{UInt8, N0f8, ColorTypes.RGB{N0f8}}
 const PermutedArray{T,N,perm,iperm,AA<:Array} = Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm,iperm,AA}
 const VidArray{T,N} = Union{Array{T,N},PermutedArray{T,N}}
 
@@ -681,10 +681,10 @@ if have_avdevice()
         DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("avfoundation")
         global CAMERA_DEVICES = String[]
         try
-            CAMERA_DEVICES = get_camera_devices(ffmpeg, "avfoundation", "\"\"")
+            global CAMERA_DEVICES = get_camera_devices(ffmpeg, "avfoundation", "\"\"")
         catch
             try
-                CAMERA_DEVICES = get_camera_devices(ffmpeg, "qtkit", "\"\"")
+                global CAMERA_DEVICES = get_camera_devices(ffmpeg, "qtkit", "\"\"")
             catch
             end
         end
@@ -698,45 +698,3 @@ if have_avdevice()
         VideoReader(camera, args...; kwargs...)
     end
 end
-
-try
-    if isa(Main.ImageView, Module)
-        # Define read and retrieve for Images
-        global playvideo, viewcam, play
-
-        function play(f, flip=false)
-            buf = read(f)
-            canvas, _ = Main.ImageView.imshow(buf, flipx=flip, interactive=false)
-
-            while !eof(f)
-                read!(f, buf)
-                Main.ImageView.imshow(canvas, buf, flipx=flip, interactive=false)
-                sleep(1/f.framerate)
-            end
-        end
-
-        function playvideo(video)
-            f = VideoIO.openvideo(video)
-            play(f)
-        end
-
-        if have_avdevice()
-            function viewcam(device=DEFAULT_CAMERA_DEVICE, format=DEFAULT_CAMERA_FORMAT)
-                camera = opencamera(device, format)
-                play(camera, true)
-            end
-        else
-            function viewcam()
-                error("libavdevice not present")
-            end
-        end
-    end
-catch
-    global playvideo, viewcam, play
-    no_imageview() = error("Please load ImageView before VideoIO to enable play(...), playvideo(...) and viewcam()")
-    play() = no_imageview()
-    playvideo() = no_imageview()
-    viewcam() = no_imageview()
-end
-
-

--- a/src/ffmpeg/AVCodecs/src/AVCodecs.jl
+++ b/src/ffmpeg/AVCodecs/src/AVCodecs.jl
@@ -2,11 +2,11 @@ module AVCodecs
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avcodec_dir, f)
 
-  using AVUtil
+  using ..AVUtil
 
   include(w("LIBAVCODEC.jl"))
 
   AVPacket() = AVPacket([T<:Ptr ? C_NULL : zero(T) for T in AVPacket.types]...)
-  
+
 end
 

--- a/src/ffmpeg/AVDevice/src/AVDevice.jl
+++ b/src/ffmpeg/AVDevice/src/AVDevice.jl
@@ -2,8 +2,8 @@ module AVDevice
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avdevice_dir, f)
 
-  using AVUtil
-  using AVFormat
-  using AVCodecs
+  using ..AVUtil
+  using ..AVFormat
+  using ..AVCodecs
   include(w("LIBAVDEVICE.jl"))
 end

--- a/src/ffmpeg/AVFilters/src/AVFilters.jl
+++ b/src/ffmpeg/AVFilters/src/AVFilters.jl
@@ -2,6 +2,6 @@ module AVFilters
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avfilter_dir, f)
 
-  using AVUtil
-  include(w("LIBAVFILTER.jl"))  
+  using ..AVUtil
+  include(w("LIBAVFILTER.jl"))
 end

--- a/src/ffmpeg/AVFormat/src/AVFormat.jl
+++ b/src/ffmpeg/AVFormat/src/AVFormat.jl
@@ -2,8 +2,8 @@ module AVFormat
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avformat_dir, f)
 
-  using AVUtil
-  using AVCodecs
+  using ..AVUtil
+  using ..AVCodecs
 
   include(w("LIBAVFORMAT.jl"))
 end

--- a/src/ffmpeg/SWResample/src/SWResample.jl
+++ b/src/ffmpeg/SWResample/src/SWResample.jl
@@ -2,6 +2,6 @@ module SWResample
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(swresample_dir, f)
 
-  using AVUtil
-  include(w("LIBSWRESAMPLE.jl"))  
+  using ..AVUtil
+  include(w("LIBSWRESAMPLE.jl"))
 end

--- a/src/ffmpeg/SWScale/src/SWScale.jl
+++ b/src/ffmpeg/SWScale/src/SWScale.jl
@@ -2,6 +2,6 @@ module SWScale
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(swscale_dir, f)
 
-  using AVUtil
+  using ..AVUtil
   include(w("LIBSWSCALE.jl"))
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -5,18 +5,14 @@ using BinDeps
 #        avcodec_version, avformat_version, avutil_version, swscale_version, avdevice_version, avfilter_version, avresample_version, swresample_version,
 #        libavcodec, libavformat, libavutil, libswscale, libavdevice, libavfilter, libavresample, libswresample,
 
-if !isdefined(:libavcodec)
+if !@isdefined(libavcodec)
     include("../deps/deps.jl")
 end
 
 INSTALL_ROOT = realpath(joinpath(splitdir(libavcodec)[1], ".."))
 
-if !isdefined(:ffmpeg_or_libav)
+if !@isdefined(ffmpeg_or_libav)
     include("version.jl")
 end
 
 av_load_path = joinpath(dirname(@__FILE__), ffmpeg_or_libav)
-!(av_load_path in LOAD_PATH) && pushfirst!(LOAD_PATH, av_load_path)
-
-
-

--- a/src/libav/AVCodecs/src/AVCodecs.jl
+++ b/src/libav/AVCodecs/src/AVCodecs.jl
@@ -2,11 +2,11 @@ module AVCodecs
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avcodec_dir, f)
 
-  using AVUtil
+  using ..AVUtil
 
   include(w("LIBAVCODEC.jl"))
 
   AVPacket() = AVPacket([T<:Ptr ? C_NULL : zero(T) for T in AVPacket.types]...)
-  
+
 end
 

--- a/src/libav/AVDevice/src/AVDevice.jl
+++ b/src/libav/AVDevice/src/AVDevice.jl
@@ -2,8 +2,8 @@ module AVDevice
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avdevice_dir, f)
 
-  using AVUtil
-  using AVFormat
-  using AVCodecs
+  using ..AVUtil
+  using ..AVFormat
+  using ..AVCodecs
   include(w("LIBAVDEVICE.jl"))
 end

--- a/src/libav/AVFormat/src/AVFormat.jl
+++ b/src/libav/AVFormat/src/AVFormat.jl
@@ -2,8 +2,8 @@ module AVFormat
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avformat_dir, f)
 
-  using AVUtil
-  using AVCodecs
+  using ..AVUtil
+  using ..AVCodecs
 
   include(w("LIBAVFORMAT.jl"))
 end

--- a/src/libav/SWScale/src/SWScale.jl
+++ b/src/libav/SWScale/src/SWScale.jl
@@ -2,7 +2,7 @@ module SWScale
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(swscale_dir, f)
 
-  using AVUtil
+  using ..AVUtil
 
   include(w("LIBSWSCALE.jl"))
 end

--- a/src/version.jl
+++ b/src/version.jl
@@ -6,8 +6,8 @@ have_avutil()     = Libdl.dlopen_e(libavutil)     != C_NULL
 have_swscale()    = Libdl.dlopen_e(libswscale)    != C_NULL
 have_avdevice()   = Libdl.dlopen_e(libavdevice)   != C_NULL
 have_avfilter()   = Libdl.dlopen_e(libavfilter)   != C_NULL
-#have_avresample() = isdefined(:libavresample) && Libdl.dlopen_e(libavresample) != C_NULL
-#have_swresample() = isdefined(:libswresample) && Libdl.dlopen_e(libswresample) != C_NULL
+#have_avresample() = @isdefined(libavresample) && Libdl.dlopen_e(libavresample) != C_NULL
+#have_swresample() = @isdefined(libswresample) && Libdl.dlopen_e(libswresample) != C_NULL
 
 _avcodec_version()    = have_avcodec()    ? av_version(ccall((:avcodec_version,    libavcodec),    UInt32, ())) : v"0"
 _avformat_version()   = have_avformat()   ? av_version(ccall((:avformat_version,   libavformat),   UInt32, ())) : v"0"


### PR DESCRIPTION
@kmsquire this is a PR into your branch from #124 

This isn't all the way done, but it's the best I can do right now, and I hope it's helpful. I fixed a few issues with 0.7+, but a few more remain:

### Load path modification

The load path modifications weren't working for me on 0.7, so I changed all of the conditional import stuff to just use `include()` as usual. I think this is an improvement anyway, as the previous behavior was dangerous: if a user happened to create a package or module called `AVUtil`, then Julia might load their AVUtil or VideoIOs, depending on the load order, causing both packages to be broken. Using `include()` avoids the issue entirely. 

However, I noticed in the Readme a note that not all of the submodules are actually loaded and a suggestion that users can load them as they see fit. That's no longer true after this change. But with precompilation, there should be no need to avoid just `include()`-ing everything. Precompilation is currently turned off for this module, so I guess the next thing to do would be to (1) move all the run-time initialization to the `__init__()` function, (2) enable precompilation (3) actually `include()` all the submodules no matter what. That should fix the issue completely and also make the package easier and more reliable to work with. 

### Conditional loading

Packages aren't loaded into `Main` in v0.7 and above, so trying to inspect `Main.ImageView` doesn't work. Fortunately https://github.com/MikeInnes/Requires.jl solves the actual issue or conditionally loading glue code, and also removes the need to load ImageView before loading VideoIO. Note that my change doesn't include the fallback `play()` methods that just print error messages, but those could be added back in. 

### Remaining deprecations

There are a few more deprecations, but they're repeated across all of the many many mostly-duplicate files and I don't have time to go through them all, sorry...

### Status

With this PR, I can at least load the package on v0.7. Testing gets as far as reading `annie_oakley.ogg` before it gets aborted with a `double free or corruption` on my Ubuntu 18.04 system with: 

```julia
julia> VideoIO.versioninfo()
Using ffmpeg
AVCodecs version 57.107.100
AVFormat version 57.83.100
AVUtil version 55.78.100
SWScale version 4.8.100
AVDevice version 57.10.100
AVFilters version 6.107.100
```