### PR TITLE
Remove trailing tab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ os:
 julia:
   - 0.6
   - nightly
-matrix:	
+matrix:
   allow_failures:
     - julia: nightly
 notifications:


### PR DESCRIPTION
It's illegal.

CIBot didn't like it since it caused YAML.jl to throw an exception when parsing the file.